### PR TITLE
Fix uninstall dropping entire conversation table

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -109,7 +109,7 @@ class ETPlugin_ConversationWarning extends ETPlugin {
 	public function uninstall()
 	{
 		$structure = ET::$database->structure();
-		$structure->table("conversation")->drop("warning");
+		$structure->table("conversation")->dropColumn("warning");
 		return true;
 	}
 }


### PR DESCRIPTION
The uninstall function used the incorrect command to remove the
warning column.  As a result it drops the entire table. This uses
the correct function, fixes issue #3